### PR TITLE
pathvisio dependency and parsing error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 *.jar
 *.war
 *.ear
+
+.classpath
+.project
+.settings/
+*~
+target/
+

--- a/add-pathvisio-maven.sh
+++ b/add-pathvisio-maven.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+## Download PathVisio
+cd /tmp
+wget http://www.pathvisio.org/data/releases/3.1.3/pathvisio_bin-3.1.3-r3968.tar.gz
+tar -xvf pathvisio_bin-3.1.3-r3968.tar.gz pathvisio-3.1.3/pathvisio.jar --strip-components 1
+
+## Install maven library
+mvn install:install-file -Dfile=pathvisio.jar -DgroupId=org.pathvisio -DartifactId=core -Dversion=3.1.3 -Dpackaging=jar
+
+## Cleanup
+rm pathvisio.jar
+rm pathvisio_bin-3.1.3-r3968.tar.gz

--- a/pom.xml
+++ b/pom.xml
@@ -57,11 +57,11 @@
 			<version>0.1.1</version>
 		</dependency>
 
-		<!-- <dependency>
+		<dependency>
 			<groupId>org.pathvisio</groupId>
 			<artifactId>core</artifactId>
-			<version>2.0.11</version>
-		</dependency> -->
+			<version>3.1.3</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/org/networklibrary/edger/App.java
+++ b/src/main/java/org/networklibrary/edger/App.java
@@ -13,6 +13,7 @@ import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.networklibrary.core.config.ConfigManager;
+import org.networklibrary.core.parsing.ParsingErrorException;
 
 /**
  * Hello world!
@@ -94,6 +95,10 @@ public class App
         catch( ParseException exp ) {
             // oops, something went wrong
             System.err.println( "Parsing failed.  Reason: " + exp.getMessage() );
-        }
+            System.exit(-1);
+        } catch (ParsingErrorException e) {
+        	System.err.println( "Parsing failed.  Reason: " + e.getMessage() );
+        	System.exit(-2);
+		}
     }
 }

--- a/src/main/java/org/networklibrary/edger/EdgeImporter.java
+++ b/src/main/java/org/networklibrary/edger/EdgeImporter.java
@@ -74,7 +74,7 @@ public class EdgeImporter {
 		this.newNodes = newNodes;
 	}
 
-	public void execute() {
+	public void execute() throws ParsingErrorException {
 
 		log.info("connecting to db: " + getDb());
 
@@ -87,7 +87,6 @@ public class EdgeImporter {
 
 		for(String fileLoc : getFileLocations()){
 			try {
-
 				Parser<EdgeData> p = makeParser();
 
 				if(p.hasExtraParameters())
@@ -108,6 +107,8 @@ public class EdgeImporter {
 				log.info("finished " + fileLoc + " in " + (elapsed/1000000000));
 			} catch (ParsingErrorException e){
 				log.severe("error during parsing of location="+fileLoc+ ": " + e.getMessage());
+				g.shutdown();
+				throw e;
 			}
 		}
 		g.shutdown();

--- a/src/main/java/org/networklibrary/edger/EdgeImporter.java
+++ b/src/main/java/org/networklibrary/edger/EdgeImporter.java
@@ -113,7 +113,7 @@ public class EdgeImporter {
 		g.shutdown();
 	}
 
-	protected Parser<EdgeData> makeParser(){
+	protected Parser<EdgeData> makeParser() throws ParsingErrorException {
 		Parser<EdgeData> p = null;
 
 		try {
@@ -121,8 +121,10 @@ public class EdgeImporter {
 			p = (Parser<EdgeData>)getParsers().get(getType()).newInstance();
 		} catch (InstantiationException e) {
 			log.severe("InstantiationException when creating parser for: " + getType() + ": " + e.getMessage());
+			throw new ParsingErrorException(e.getMessage());
 		} catch (IllegalAccessException e) {
 			log.severe("IllegalAccessException when creating parser for: " + getType() + ": " + e.getMessage());
+			throw new ParsingErrorException(e.getMessage());
 		}
 
 		return p;


### PR DESCRIPTION
Some changes to properly deal with PathVisio dependency (shell script do download from pathvisio.org and updated depencency in pom.xml), plus small change to propagate parsing error and exit with non-zero status instead of swallowing it with only log message.
